### PR TITLE
Pinning To Swift NIO 2.86.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -9,10 +9,14 @@ let package = Package(
         .library(name: "AWSSigner", targets: ["AWSSigner"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio", .upToNextMajor(from: "2.13.1"))
+        .package(url: "https://github.com/apple/swift-nio", exact: "2.86.2")
     ],
     targets: [
-        .target(name: "AWSSigner", dependencies: ["AWSCrypto", "NIO", "NIOHTTP1"]),
+        .target(name: "AWSSigner", dependencies: [
+            "AWSCrypto",
+            .product(name: "NIO", package: "swift-nio"),
+            .product(name: "NIOHTTP1", package: "swift-nio")
+        ]),
         .target(name: "AWSCrypto", dependencies: []),
         
         .testTarget(name: "AWSSignerTests", dependencies: ["AWSSigner"])
@@ -31,3 +35,4 @@ if useSwiftCrypto {
     package.dependencies.append(.package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"))
     package.targets.first{$0.name == "AWSCrypto"}?.dependencies.append("Crypto")
 }
+

--- a/Sources/AWSCrypto/HMAC.swift
+++ b/Sources/AWSCrypto/HMAC.swift
@@ -31,7 +31,7 @@ public struct HMAC<H: CCHashFunction> {
         }) {
             return digest
         } else {
-            var buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: data.count)
+            let buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: data.count)
             data.copyBytes(to: buffer)
             defer { buffer.deallocate() }
             self.update(bufferPointer: .init(buffer))

--- a/Sources/AWSCrypto/HashFunction.swift
+++ b/Sources/AWSCrypto/HashFunction.swift
@@ -39,7 +39,7 @@ extension HashFunction {
         }) {
             return digest
         } else {
-            var buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: data.count)
+            let buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: data.count)
             data.copyBytes(to: buffer)
             defer { buffer.deallocate() }
             return self.hash(bufferPointer: .init(buffer))
@@ -53,7 +53,7 @@ extension HashFunction {
         }) {
             return digest
         } else {
-            var buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: data.count)
+            let buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: data.count)
             data.copyBytes(to: buffer)
             defer { buffer.deallocate() }
             self.update(bufferPointer: .init(buffer))

--- a/Sources/AWSSigner/credentials.swift
+++ b/Sources/AWSSigner/credentials.swift
@@ -7,7 +7,7 @@
 import class Foundation.ProcessInfo
 
 /// Protocol for providing credential details for accessing AWS services
-public protocol Credential {
+public protocol Credential: Sendable {
     var accessKeyId: String {get}
     var secretAccessKey: String {get}
     var sessionToken: String? {get}

--- a/Sources/AWSSigner/signer.swift
+++ b/Sources/AWSSigner/signer.swift
@@ -19,7 +19,7 @@ import NIO
 import NIOHTTP1
 
 /// Amazon Web Services V4 Signer
-public struct AWSSigner {
+public struct AWSSigner: Sendable {
     /// security credentials for accessing AWS services
     public let credentials: Credential
     /// service signing name. In general this is the same as the service name


### PR DESCRIPTION
When submitting a Catalyst app using this library I started getting the binary rejected by App Store Connect. Validation succeeded but then I'd later get an email from Apple saying: 

ITMS-90714: Invalid binary - The app contains one or more corrupted binaries. Please rebuild the app and resubmit.

This only seems to affect the Catalyst build. The iOS build is fine. 

After a lot of bisecting of changes I traced it back to using `SwiftNIO 2.88.0`. Reverting that to the previous working version, `2.86.2`, fixes the issue. 

No idea what it is about 2.88.0 that it doesn't like. There are no details or logs to go on. 

This pins this library to use 2.86.2.

Additionally, I've updated to using the latest swift tools version and fixed up a few warnings coming from Swift 6 and strict conccurency. 